### PR TITLE
Postgres v1.4 - Implemented req-res round trip time log middleware

### DIFF
--- a/src/coffees/coffees.controller.ts
+++ b/src/coffees/coffees.controller.ts
@@ -6,6 +6,7 @@ import {
   HttpCode,
   HttpStatus,
   Param,
+  ParseIntPipe,
   Patch,
   Post,
   Put,
@@ -56,9 +57,10 @@ export class CoffeesController {
   //     .send('This action returns via express exposed response library methods');
   // }
 
+  // pass custom created ParseIntPipe as `@Param()` injector to enforce integer validation of request
   @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.coffeesService.findOne(id);
+  findOne(@Param('id', ParseIntPipe) id: string) {
+    return this.coffeesService.findOne('' + id);
   }
 
   @Post()

--- a/src/common/common.module.ts
+++ b/src/common/common.module.ts
@@ -1,7 +1,13 @@
-import { Module } from '@nestjs/common';
+import {
+  MiddlewareConsumer,
+  Module,
+  NestModule,
+  RequestMethod,
+} from '@nestjs/common';
 import { APP_GUARD } from '@nestjs/core';
 import { ApiKeyGuard } from './guards/api-key/api-key.guard';
 import { ConfigModule } from '@nestjs/config';
+import { LoggingMiddleware } from './middleware/logging/logging.middleware';
 
 /**
  * Set up COMMON Module to allow for global/common Guards, similar to `app.useGlobalGuards()`
@@ -12,7 +18,16 @@ import { ConfigModule } from '@nestjs/config';
   imports: [ConfigModule], // <-- allows for ConfigService use in our Guard
   // providers: [{ provide: APP_GUARD, useClass: ApiKeyGuard }], // <-- this implements ApiKeyGuard GLOBALLY **
 })
-export class CommonModule {}
+export class CommonModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(LoggingMiddleware).forRoutes('*'); // <-- binds middleware argument to EVERY route (wildcard)
+    // consumer.apply(LoggingMiddleware).forRoutes('coffees'); // <-- binds middleware argument to 'coffees' routes
+    // consumer.apply(LoggingMiddleware).exclude('coffees').forRoutes('*'); // <-- binds middleware argument to '*', exludes 'coffees'
+    // consumer
+    //   .apply(LoggingMiddleware)
+    //   .forRoutes({ path: 'coffees', method: RequestMethod.GET }); // <-- only binds middleware argument to 'coffees' GET methods
+  }
+}
 
 // ** For more pointed implementation: @UseGuards(ApiKeyGuard)` Decorator under @Controller('...') for ex.
 // passing in the Class instead of an Instance (`new`) leaves instantiation to the framework and enables dependency injection

--- a/src/common/guards/api-key/api-key.guard.ts
+++ b/src/common/guards/api-key/api-key.guard.ts
@@ -26,7 +26,7 @@ export class ApiKeyGuard implements CanActivate {
     }
     const request = context.switchToHttp().getRequest<Request>(); // Request from Fetch API (might need to be from express...)
     const authHeader = request.header('Authorization');
-    return authHeader === this.configService.get('API_KEY');
+    return authHeader === this.configService.get('API_KEY'); // ** <-- THIS IS BEST PRACTICE FOR .ENV ACCESS
     // return authHeader === process.env.API_KEY; // <-- same as above, but raw .env syntax w/o `configService.get()` (less safe)
   }
 }

--- a/src/common/middleware/logging/logging.middleware.spec.ts
+++ b/src/common/middleware/logging/logging.middleware.spec.ts
@@ -1,0 +1,7 @@
+import { LoggingMiddleware } from './logging.middleware';
+
+describe('LoggingMiddleware', () => {
+  it('should be defined', () => {
+    expect(new LoggingMiddleware()).toBeDefined();
+  });
+});

--- a/src/common/middleware/logging/logging.middleware.ts
+++ b/src/common/middleware/logging/logging.middleware.ts
@@ -1,0 +1,18 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+
+/**
+ * Middleware (class or function based (function has to be stateless)) must ALWAYS call `next()` or be left hanging
+ * in Nest we bing middleware to a "route path" represented as a String (see `common.module.ts` for registering)
+ *
+ * This example Class will track round trip time for each http-request (we registered to '*' routes in `common-module.ts`)
+ */
+
+@Injectable()
+export class LoggingMiddleware implements NestMiddleware {
+  use(req: any, res: any, next: () => void) {
+    // console.log('Hi from middleware!');
+    console.time('Request-response time');
+    res.on('finish', () => console.timeEnd('Request-response time')); // <-- hooking into Express `response` 'finish' event
+    next();
+  }
+}

--- a/src/common/pipes/parse-int/parse-int.pipe.spec.ts
+++ b/src/common/pipes/parse-int/parse-int.pipe.spec.ts
@@ -1,0 +1,7 @@
+import { ParseIntPipe } from './parse-int.pipe';
+
+describe('ParseIntPipe', () => {
+  it('should be defined', () => {
+    expect(new ParseIntPipe()).toBeDefined();
+  });
+});

--- a/src/common/pipes/parse-int/parse-int.pipe.ts
+++ b/src/common/pipes/parse-int/parse-int.pipe.ts
@@ -1,0 +1,31 @@
+import {
+  ArgumentMetadata,
+  BadRequestException,
+  Injectable,
+  PipeTransform,
+} from '@nestjs/common';
+
+/**
+ * All Pipes will implement the `PipeTransform` interface --> requires `transform()` method inside Class.
+ * Pipes will sit between the **client request** and the **request handler**
+ * `transform()` receives TWO arguments:
+ * `value`: the input of the currently processed argument before it is received by our route handling method.
+ *
+ * `metaData`: The metadata of the currently processed argument (where it sits in the Nest IoC Scope)
+ *
+ * --> whatever occurs inside `transform` will override the previous value of the argument
+ * --> EX. USECASE: we can use default values to fill in our DTO if it is missing props/values before hitting route handler
+ */
+
+@Injectable()
+export class ParseIntPipe implements PipeTransform {
+  transform(value: string, metadata: ArgumentMetadata) {
+    const val = parseInt(value, 10);
+    if (isNaN(val)) {
+      throw new BadRequestException(
+        `Validation failed "${val}" is not an integer.`,
+      );
+    }
+    return val;
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,6 +34,7 @@ async function bootstrap() {
   // app.useStaticAssets(join(__dirname, '..', 'public')); // <-- for shared image/static assets
   // app.setBaseViewsDir(join(__dirname, '..', 'views')); // <-- for `index.html` / views (components?)
   // app.setViewEngine('hbs');
+
   app.useGlobalFilters(new HttpExceptionFilter()); // <-- apply `filters/http-exception/http-exception.filter.ts` for global http requests
   // app.useGlobalGuards(new ApiKeyGuard()); // <-- apply global Guard here (only if Argument needs NO dependencies...)
   app.useGlobalInterceptors(


### PR DESCRIPTION
used `nest g middleware` to generate and coded out `console.time()` hooked into Express `res` object. Registered through `common-module` which is imported in `app.module.ts` and watching wildcard `'*'` all routes